### PR TITLE
Build binutils without -Werror

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,8 @@ REDIST_DJGPP="$HERE/redist-djgpp"
 PARALLEL="-j 4"
 #PARALLEL=""
 BINUTILSOPTS="--enable-ld=default --enable-gold=yes ` \
-	     `--enable-targets=ia16-elf --enable-x86-hpa-segelf=yes"
+	     `--enable-targets=ia16-elf --enable-x86-hpa-segelf=yes ` \
+	     `--disable-werror"
 AUTOTESTPARALLEL="-j4"
 export SHELL=/bin/bash  # make sure subshells, e.g. in `script', are also bash
 


### PR DESCRIPTION
At least with glibc 2.33 on Linux, the following error occurs:

```
../../binutils-ia16/gold/main.cc: In function ‘int main(int, char**)’:
../../binutils-ia16/gold/main.cc:301:36: error: ‘mallinfo mallinfo()’ is deprecated [-Werror=deprecated-declarations]
  301 |       struct mallinfo m = mallinfo();
      |                                    ^
In file included from ../../binutils-ia16/gold/main.cc:35:
/usr/include/malloc.h:118:24: note: declared here
  118 | extern struct mallinfo mallinfo (void) __THROW __MALLOC_DEPRECATED;
      |
```

mallinfo() is marked as deprecated, and -Werror is forcing this harmless
diagnostic to be an error. Ultimately the proper solution will be to
avoid mallinfo(), but this is a quick fix to allow things to build.